### PR TITLE
Fix queue state when rebuilding research tree

### DIFF
--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -151,6 +151,7 @@ public class MainTabWindow_ResearchTree : MainTabWindow
 
     public void Notify_TreeInitialized()
     {
+        Queue.Notify_TreeReinitialized();
         setRects();
     }
 


### PR DESCRIPTION
## Summary
- clear and restore the queued research projects when rebuilding the tree so residual queue numbers disappear
- rehydrate the queue after the tree is reinitialized and skip drawing labels while the tree is rebuilding
- respect the caller's desire to keep the research tab closed, and avoid showing the RimWorld loading screen when regenerating the tree

## Testing
- `dotnet build ResearchTree.slnx` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ce482614108328866374d9f14773a0