### PR TITLE
Close dialog before rebuilding research tree

### DIFF
--- a/Source/ResearchTree/Dialog_SelectResearchTabs.cs
+++ b/Source/ResearchTree/Dialog_SelectResearchTabs.cs
@@ -211,6 +211,9 @@ namespace FluffyResearchTree
             // 触发刷新（现有窗口与绘制管线会据此刷新/重建）
             Assets.RefreshResearch = true;
             bool wasResearchOpen = Find.MainTabsRoot.OpenTab == MainButtonDefOf.Research;
+
+            // 先关闭当前窗口，避免在重建过程中卡着等待
+            Close(doCloseSound: true);
             if (wasResearchOpen)
             {
                 Find.MainTabsRoot.ToggleTab(MainButtonDefOf.Research);
@@ -219,7 +222,6 @@ namespace FluffyResearchTree
             Tree.RequestRebuild(resetZoom: true, reopenResearchTab: false);
 
             Messages.Message("Fluffy.ResearchTree.refresh".Translate(), MessageTypeDefOf.TaskCompletion, historical: false);
-            Close(doCloseSound: true);
         }
 
         // ====== 小工具：GUI 颜色域 ======


### PR DESCRIPTION
## Summary
- close the tab selection dialog before triggering the research tree rebuild
- keep the research tab toggle and rebuild logic intact to avoid UI stalls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce6961932c83289b9e765ba56f4c6d