### PR TITLE
Fix lingering highlighted edges when node offscreen

### DIFF
--- a/Source/ResearchTree/Tree.cs
+++ b/Source/ResearchTree/Tree.cs
@@ -1183,11 +1183,13 @@ public static class Tree
         {
             if (NodeHiddenBySkipCompleted(node))
             {
+                clearHighlight(node);
                 continue;
             }
 
             if (!node.IsWithinViewport(visibleRect))
             {
+                clearHighlight(node);
                 continue;
             }
 
@@ -1309,6 +1311,16 @@ public static class Tree
         }
     }
 
+    private static void clearHighlight(Node node)
+    {
+        if (node is DummyNode)
+        {
+            return;
+        }
+
+        node.Highlighted = false;
+    }
+
     private static void collectVisibleNodes(Rect visibleRect, int minLayer, int maxLayer, int minRow, int maxRow)
     {
         VisibleNodesBuffer.Clear();
@@ -1320,11 +1332,13 @@ public static class Tree
             {
                 if (!node.IsVisible || NodeHiddenBySkipCompleted(node))
                 {
+                    clearHighlight(node);
                     continue;
                 }
 
                 if (!node.IsWithinViewport(visibleRect))
                 {
+                    clearHighlight(node);
                     continue;
                 }
 
@@ -1361,11 +1375,13 @@ public static class Tree
 
                 if (!node.IsVisible || NodeHiddenBySkipCompleted(node))
                 {
+                    clearHighlight(node);
                     continue;
                 }
 
                 if (!node.IsWithinViewport(visibleRect))
                 {
+                    clearHighlight(node);
                     continue;
                 }
 


### PR DESCRIPTION
## Summary
- clear highlight state for nodes skipped during viewport culling so their edges return to normal after hover ends
- ensure nodes skipped in the non-culling rendering path also reset their highlight state

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce9df328d88328aea1ff5b5c3bdefa