### PR TITLE
Fix default tab selections without re-adding on cache refresh

### DIFF
--- a/Languages/ChineseSimplified/Keyed/KeyedTranslations.xml
+++ b/Languages/ChineseSimplified/Keyed/KeyedTranslations.xml
@@ -42,6 +42,7 @@
   <Fluffy.ResearchTree.ShowCompletion>研究完成后弹出完成对话框</Fluffy.ResearchTree.ShowCompletion>
   <Fluffy.ResearchTree.StillLoading>研究树首次加载，可能需要一段时间</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>研究树未生成结束，请稍候……</Fluffy.ResearchTree.GenerationInProgress>
+  <Fluffy.ResearchTree.NoTabsSelected>当前未选择任何研究项目</Fluffy.ResearchTree.NoTabsSelected>
   <Fluffy.ResearchTree.UIScaleWarning>如果使用后台加载选项，当用户界面比例大于 1x 时，可能会出现研究标签被切断的情况。
 如果遇到这种情况，请使用首次打开时加载。</Fluffy.ResearchTree.UIScaleWarning>
   <Fluffy.ResearchTree.CtrlFunctionScroll>使用 Ctrl 键垂直滚动研究树</Fluffy.ResearchTree.CtrlFunctionScroll>

--- a/Languages/ChineseTraditional/Keyed/KeyedTranslations.xml
+++ b/Languages/ChineseTraditional/Keyed/KeyedTranslations.xml
@@ -42,6 +42,7 @@
   <Fluffy.ResearchTree.ShowCompletion>研究完成後彈出完成對話框</Fluffy.ResearchTree.ShowCompletion>
   <Fluffy.ResearchTree.StillLoading>研究樹首次載入，可能需要一段時間</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>研究樹尚未生成完成，請稍候……</Fluffy.ResearchTree.GenerationInProgress>
+  <Fluffy.ResearchTree.NoTabsSelected>目前未選擇任何研究項目</Fluffy.ResearchTree.NoTabsSelected>
   <Fluffy.ResearchTree.UIScaleWarning>如果使用背景載入選項，當使用者介面比例大於 1x 時，可能會出現研究標籤被切斷的情況。
 如果遇到這種情況，請使用首次開啟時載入。</Fluffy.ResearchTree.UIScaleWarning>
   <Fluffy.ResearchTree.CtrlFunctionScroll>使用 Ctrl 鍵垂直捲動研究樹</Fluffy.ResearchTree.CtrlFunctionScroll>

--- a/Languages/English/Keyed/KeyedTranslations.xml
+++ b/Languages/English/Keyed/KeyedTranslations.xml
@@ -37,6 +37,7 @@
   <Fluffy.ResearchTree.ShowCompletion>Show completion message for finished research</Fluffy.ResearchTree.ShowCompletion>
   <Fluffy.ResearchTree.StillLoading>Tree is loading for the first time, this can take a while</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>Research tree generation is still in progress, please wait…</Fluffy.ResearchTree.GenerationInProgress>
+  <Fluffy.ResearchTree.NoTabsSelected>No research projects are available because no research tags are selected.</Fluffy.ResearchTree.NoTabsSelected>
   <Fluffy.ResearchTree.LoadingWait>Tree not finished generating, click to open vanilla tree</Fluffy.ResearchTree.LoadingWait>
   <Fluffy.ResearchTree.CurrentModVersion>Installed mod-version: {0}</Fluffy.ResearchTree.CurrentModVersion>
   <Fluffy.ResearchTree.PauseOnOpen>Pause game on opening research-tree</Fluffy.ResearchTree.PauseOnOpen>

--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -271,6 +271,12 @@ public class MainTabWindow_ResearchTree : MainTabWindow
             ApplyTreeInitializedState();
         }
 
+        if (Tree.NoTabsSelected)
+        {
+            DrawNoTabsSelectedMessage(canvas);
+            return;
+        }
+
         // 先处理输入（同帧生效）
         handleZoom();
         handleDolly();
@@ -311,6 +317,33 @@ public class MainTabWindow_ResearchTree : MainTabWindow
         GUI.color = Color.yellow;
         Text.Anchor = TextAnchor.MiddleCenter;
         Widgets.Label(messageRect, "Fluffy.ResearchTree.GenerationInProgress".Translate());
+        Text.Anchor = TextAnchor.UpperLeft;
+        GUI.color = previousColor;
+    }
+
+    private void DrawNoTabsSelectedMessage(Rect canvas)
+    {
+        var messageRect = new Rect(
+            canvas.xMin,
+            canvas.yMin + Constants.TopBarHeight,
+            canvas.width,
+            Mathf.Max(0f, canvas.height - Constants.TopBarHeight));
+
+        if (messageRect.height <= 0f)
+        {
+            return;
+        }
+
+        messageRect = messageRect.ContractedBy(Constants.Margin);
+        if (messageRect.height <= 0f)
+        {
+            return;
+        }
+
+        var previousColor = GUI.color;
+        GUI.color = Color.white;
+        Text.Anchor = TextAnchor.MiddleCenter;
+        Widgets.Label(messageRect, "Fluffy.ResearchTree.NoTabsSelected".Translate());
         Text.Anchor = TextAnchor.UpperLeft;
         GUI.color = previousColor;
     }


### PR DESCRIPTION
## Summary
- add a saved TabsInitialized flag so we know when the tab filter has been intentionally configured
- rebuild IncludedTabs from the cached tab list during Reset and mark the selection initialized
- stop EnsureTabCache from re-adding every tab each time it runs and only seed the selection during first initialization

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d25fd8d4488328a905dc7918d50420