### PR TITLE
Prune missing research tabs from settings

### DIFF
--- a/Docs/ManualTestPlan.md
+++ b/Docs/ManualTestPlan.md
@@ -1,0 +1,20 @@
+# Manual Test Plan: Research Tab Pruning
+
+This scenario verifies that uninstalling a modded research tab cannot break the tree population.
+
+## Prerequisites
+* Launch RimWorld with the Fluffy Research Tree mod enabled.
+* Start a save that previously had at least one extra research tab provided by another mod. Ensure that the extra mod is now disabled.
+
+## Steps
+1. Start RimWorld and load the affected save.
+2. Open the mod settings for **Research Tree** from the main menu.
+3. Observe the list of tabs in the right-hand column.
+   * Confirm that only tabs still provided by active mods are listed.
+4. Close the settings window.
+5. Open the research tree.
+
+## Expected Results
+* The research tree opens successfully and displays all remaining research tabs.
+* No errors are logged about missing tab definitions.
+* Reopening the settings shows only valid tabs selected; the previously uninstalled tab does not reappear.

--- a/Source/ResearchTree/FluffyResearchTreeSettings.cs
+++ b/Source/ResearchTree/FluffyResearchTreeSettings.cs
@@ -108,6 +108,21 @@ internal class FluffyResearchTreeSettings : ModSettings
 
         IncludedTabs ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        var validTabNames = new HashSet<string>(
+            AllTabsCache.Where(tab => tab != null).Select(tab => tab.defName),
+            StringComparer.OrdinalIgnoreCase);
+
+        var settingsDirty = false;
+
+        if (IncludedTabs.Count > 0)
+        {
+            var removedCount = IncludedTabs.RemoveWhere(name => !validTabNames.Contains(name));
+            if (removedCount > 0)
+            {
+                settingsDirty = true;
+            }
+        }
+
         if (!TabsInitialized)
         {
             foreach (var tab in AllTabsCache)
@@ -117,6 +132,18 @@ internal class FluffyResearchTreeSettings : ModSettings
             }
 
             TabsInitialized = true;
+        }
+
+        if (IncludedTabs.Count == 0 && validTabNames.Count > 0)
+        {
+            IncludedTabs = new HashSet<string>(validTabNames, StringComparer.OrdinalIgnoreCase);
+            TabsInitialized = true;
+            settingsDirty = true;
+        }
+
+        if (settingsDirty)
+        {
+            FluffyResearchTreeMod.instance?.WriteSettings();
         }
 
         foreach (var tab in AllTabsCache)


### PR DESCRIPTION
## Summary
- prune orphaned tab IDs from the stored settings when mods are removed and write the cleaned values back to disk
- repopulate the included tab list with all known tabs if pruning would otherwise leave the set empty
- document a manual regression test that covers uninstalling a modded research tab

## Testing
- `dotnet build Source/ResearchTree/FluffyResearchTree.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d2763f220883288bd5cefaf06b70d1