### PR TITLE
Add performance logging for research tree initialization

### DIFF
--- a/Source/ResearchTree/Logging.cs
+++ b/Source/ResearchTree/Logging.cs
@@ -7,11 +7,28 @@ namespace FluffyResearchTree;
 
 public static class Logging
 {
+    private const string PerformancePrefix = "[Performance]";
+
     public static void Message(string message)
     {
         if (FluffyResearchTreeMod.instance.Settings.VerboseLogging)
         {
             Log.Message(format(message));
+        }
+    }
+
+    public static void Performance(string label, long elapsedMilliseconds, long warnThresholdMilliseconds = 250)
+    {
+        var formatted = format($"{PerformancePrefix} {label} took {elapsedMilliseconds} ms (threshold {warnThresholdMilliseconds} ms)");
+        if (elapsedMilliseconds >= warnThresholdMilliseconds)
+        {
+            Log.Warning(formatted);
+            return;
+        }
+
+        if (FluffyResearchTreeMod.instance?.Settings?.VerboseLogging ?? false)
+        {
+            Log.Message(formatted);
         }
     }
 


### PR DESCRIPTION
## Summary
- add a dedicated performance logger that highlights slow operations unless verbose logging is enabled
- instrument research tree window opening and first draw to emit timing information when the UI stalls
- profile initialization and the first tree draw so large delays can be correlated with node and edge counts

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2a1dd3b1083288d195fc4a6eaf732