### PR TITLE
Fix research tree window input capture and refresh viewport bounds

### DIFF
--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -132,6 +132,11 @@ public class MainTabWindow_ResearchTree : MainTabWindow
         }
     }
 
+    internal static void InvalidateTreeRectCache()
+    {
+        _treeRect = default;
+    }
+
     private Rect VisibleRect => new(_scrollPosition.x, _scrollPosition.y, ViewRect_Inner.width, ViewRect_Inner.height);
 
     private float MaxZoomLevel
@@ -161,8 +166,10 @@ public class MainTabWindow_ResearchTree : MainTabWindow
     public void Notify_TreeInitialized()
     {
         Assets.RefreshResearch = true;
+        InvalidateTreeRectCache();
         setRects();
         ApplyTreeInitializedState();
+        ClampScroll();
     }
 
     public override void PreOpen()
@@ -173,8 +180,8 @@ public class MainTabWindow_ResearchTree : MainTabWindow
         {
             base.PreOpen();
 
-            // 关键：吸收窗口周围输入，防止事件下沉到地图/底层 UI
-            absorbInputAroundWindow = true;
+            // 仅在窗口内部吸收输入，允许底部主按钮响应
+            absorbInputAroundWindow = false;
             closeOnClickedOutside = false;   // 避免 RimWorld 的“点外面就关”的默认行为
             preventCameraMotion = true;      // 避免地图摄像机因这个点击而响应
 

--- a/Source/ResearchTree/Tree.cs
+++ b/Source/ResearchTree/Tree.cs
@@ -212,6 +212,7 @@ public static class Tree
         Initialized = false;
         OrderDirty = false;
         FirstLoadDone = false;
+        MainTabWindow_ResearchTree.InvalidateTreeRectCache();
         if (MainTabWindow_ResearchTree.Instance != null)
         {
             if (alsoZoom)


### PR DESCRIPTION
## Summary
- allow the bottom main buttons to remain clickable while the research tree window is open by stopping the window from absorbing off-window input
- reset the cached tree rect when the tree is rebuilt so scroll bounds cover the regenerated layout

## Testing
- not run (game assemblies not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3c0da2cc0832899c12cff7c1b3fc1