### PR TITLE
Prevent map clicks from closing research tree

### DIFF
--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -331,12 +331,41 @@ public class MainTabWindow_ResearchTree : MainTabWindow
         GUI.color = Color.white;
         Text.Anchor = TextAnchor.UpperLeft;
 
+        AbsorbUnclaimedInput();
+
         if (firstDrawTimer != null)
         {
             firstDrawTimer.Stop();
             Logging.Performance("MainTabWindow_ResearchTree.DoWindowContents.FirstDraw",
                 firstDrawTimer.ElapsedMilliseconds, FirstDrawWarnThresholdMs);
             _logFirstDrawNextFrame = false;
+        }
+    }
+
+    private void AbsorbUnclaimedInput()
+    {
+        var e = Event.current;
+        if (!e.isMouse)
+        {
+            return;
+        }
+
+        if (e.type == EventType.Used)
+        {
+            return;
+        }
+
+        if (!Mouse.IsOver(windowRect))
+        {
+            return;
+        }
+
+        switch (e.type)
+        {
+            case EventType.MouseDown:
+            case EventType.MouseUp:
+                e.Use();
+                break;
         }
     }
 


### PR DESCRIPTION
## Summary
- consume unhandled mouse presses that occur within the research tree window
- stop clicks on empty tree areas from bubbling to the map and closing the tab

## Testing
- dotnet build Source/ResearchTree/FluffyResearchTree.csproj *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d40200f74c83289c6e39b6750cab8b