### PR TITLE
Optimize tree redraws during panning

### DIFF
--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -322,9 +322,14 @@ public class MainTabWindow_ResearchTree : MainTabWindow
             firstDrawTimer = Stopwatch.StartNew();
         }
 
+        var skipTreeDraw = ShouldSkipTreeDrawThisEvent();
+
         _scrollPosition = GUI.BeginScrollView(ViewRect, _scrollPosition, TreeRect, true, true);
-        Tree.Draw(VisibleRect);
-        Queue.DrawLabels(VisibleRect);
+        if (!skipTreeDraw)
+        {
+            Tree.Draw(VisibleRect);
+            Queue.DrawLabels(VisibleRect);
+        }
         GUI.EndScrollView(false);
         ResetZoomLevel();
         GUI.color = Color.white;
@@ -338,6 +343,28 @@ public class MainTabWindow_ResearchTree : MainTabWindow
             Logging.Performance("MainTabWindow_ResearchTree.DoWindowContents.FirstDraw",
                 firstDrawTimer.ElapsedMilliseconds, FirstDrawWarnThresholdMs);
             _logFirstDrawNextFrame = false;
+        }
+    }
+
+    private bool ShouldSkipTreeDrawThisEvent()
+    {
+        var evt = Event.current;
+        if (evt == null)
+        {
+            return false;
+        }
+
+        switch (evt.type)
+        {
+            case EventType.Layout:
+                return true;
+            case EventType.MouseDrag:
+                return _panning;
+            case EventType.ScrollWheel:
+                // 滚轮事件会紧跟一个 Repaint，再绘制即可
+                return true;
+            default:
+                return false;
         }
     }
 


### PR DESCRIPTION
## Summary
- skip expensive tree and queue drawing when processing layout, scroll and panning drag events
- keep rendering to the repaint cycle so visual updates only happen once per frame while interactions still work

## Testing
- dotnet build Source/ResearchTree/FluffyResearchTree.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d500a2fc908328bed295cee99bceff