### PR TITLE
Fix drag region detection near top of research tree

### DIFF
--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -116,6 +116,25 @@ public class MainTabWindow_ResearchTree : MainTabWindow
         }
     }
 
+    private Rect InteractionRect
+    {
+        get
+        {
+            var rect = ViewRect;
+            var zoom = ZoomLevel;
+
+            if (!Mathf.Approximately(zoom, 1f) && zoom > 0f)
+            {
+                rect.xMin /= zoom;
+                rect.yMin /= zoom;
+                rect.width /= zoom;
+                rect.height /= zoom;
+            }
+
+            return rect;
+        }
+    }
+
     private static Rect TreeRect
     {
         get
@@ -521,7 +540,7 @@ public class MainTabWindow_ResearchTree : MainTabWindow
 
         // 先确认鼠标在窗口内（不是只看 ViewRect）
         bool inWindow = Mouse.IsOver(this.windowRect);
-        bool inView = inWindow && ViewRect.Contains(e.mousePosition);
+        bool inView = inWindow && InteractionRect.Contains(e.mousePosition);
 
         if (e.type == EventType.MouseDown && inWindow)
         {


### PR DESCRIPTION
## Summary
- add an interaction rect that normalizes the tree view bounds
- rely on the normalized rect when deciding whether dragging can start

## Testing
- dotnet build Source/ResearchTree/FluffyResearchTree.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d54ed8bc4c83288ecfcfd446ba8fca