### PR TITLE
Fix float direction inference in collapsed edge rendering

### DIFF
--- a/Source/ResearchTree/Tree.cs
+++ b/Source/ResearchTree/Tree.cs
@@ -134,7 +134,7 @@ public static class Tree
             {
                 var horizontalSpan = Math.Abs(end.x - start.x);
                 var stub = Math.Min(Constants.NodeMargins.x / 4f, horizontalSpan / 2f);
-                var direction = Math.Sign(end.x - start.x);
+                var direction = Mathf.Sign(end.x - start.x);
                 if (Math.Abs(direction) < Constants.Epsilon)
                 {
                     direction = 1f;


### PR DESCRIPTION
## Summary
- use Mathf.Sign when calculating collapsed edge direction so it is inferred as a float
- prevent the build failure caused by assigning a float literal to an int direction variable

## Testing
- `dotnet build Source/ResearchTree/ResearchTree.slnx` *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ec97aa65a48328b108900f3f4c58da