### PR TITLE
Handle multi-button capture while research tree is open

### DIFF
--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -44,7 +44,7 @@ public class MainTabWindow_ResearchTree : MainTabWindow
     private bool _panning;                 // 是否已进入平移
     private Vector2 _dragStart;            // 按下时坐标
     private const float PanThreshold = 4f; // 启动平移的像素阈值（避免轻点触发）
-    private int _capturedMouseButton = -1; // 记录始于窗口内部的鼠标按钮
+    private readonly HashSet<int> _capturedMouseButtons = new(); // 记录始于窗口内部的鼠标按钮
     private const float TopBarControlGap = 6f;
     private const float TopBarLabelPadding = 24f;
     private const float TopBarMinSearchWidth = 220f;
@@ -191,7 +191,7 @@ public class MainTabWindow_ResearchTree : MainTabWindow
             Assets.RefreshResearch = true;
             _dragging = false;
             closeOnClickedOutside = false;
-            _capturedMouseButton = -1;
+            _capturedMouseButtons.Clear();
 
             _cachedUnlockedDefsGroupedByPrerequisites = null;
             _cachedVisibleResearchProjects = null;
@@ -358,7 +358,7 @@ public class MainTabWindow_ResearchTree : MainTabWindow
         }
 
         var pointerOverWindow = Mouse.IsOver(windowRect);
-        var capturing = _capturedMouseButton != -1;
+        var capturing = _capturedMouseButtons.Count > 0;
 
         if (!pointerOverWindow && !capturing)
         {
@@ -373,7 +373,7 @@ public class MainTabWindow_ResearchTree : MainTabWindow
                 e.Use();
                 break;
             case EventType.MouseDrag:
-                if (!capturing || (e.button != _capturedMouseButton && _capturedMouseButton != -1))
+                if (!capturing || !_capturedMouseButtons.Contains(e.button))
                 {
                     return;
                 }
@@ -381,11 +381,7 @@ public class MainTabWindow_ResearchTree : MainTabWindow
                 e.Use();
                 break;
             case EventType.MouseUp:
-                if (capturing && e.button == _capturedMouseButton)
-                {
-                    _capturedMouseButton = -1;
-                }
-
+                _capturedMouseButtons.Remove(e.button);
                 e.Use();
                 break;
         }
@@ -501,10 +497,7 @@ public class MainTabWindow_ResearchTree : MainTabWindow
 
         if (e.type == EventType.MouseDown && inWindow)
         {
-            if (_capturedMouseButton == -1)
-            {
-                _capturedMouseButton = e.button;
-            }
+            _capturedMouseButtons.Add(e.button);
 
             _dragging = inView && e.button == 0; // 只有左键才触发平移
             _panning = false;
@@ -513,15 +506,18 @@ public class MainTabWindow_ResearchTree : MainTabWindow
             return;
         }
 
-        if (e.type == EventType.MouseUp && e.button == _capturedMouseButton)
+        if (e.type == EventType.MouseUp && _capturedMouseButtons.Remove(e.button))
         {
-            _dragging = _panning = false;
-            _dragStart = _mousePosition = Vector2.zero;
-            _capturedMouseButton = -1;
+            if (e.button == 0)
+            {
+                _dragging = _panning = false;
+                _dragStart = _mousePosition = Vector2.zero;
+            }
+
             return;
         }
 
-        if (_dragging && e.type == EventType.MouseDrag && e.button == _capturedMouseButton)
+        if (_dragging && e.type == EventType.MouseDrag && _capturedMouseButtons.Contains(e.button))
         {
             if (!_panning)
             {


### PR DESCRIPTION
## Summary
- track all mouse buttons pressed inside the research tree window so subsequent drags are absorbed
- update drag handling to release captured buttons individually and continue swallowing left-drag events

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec97bd79ec8328bef94aaa2c7fe932