### PR TITLE
Handle missing prerequisite nodes when checking availability

### DIFF
--- a/Source/ResearchTree/ResearchNode.cs
+++ b/Source/ResearchTree/ResearchNode.cs
@@ -260,13 +260,12 @@ public class ResearchNode : Node
                     continue;
                 }
 
-                if (researchPrerequisite.ResearchNode().Available)
+                var prerequisiteNode = researchPrerequisite.ResearchNode();
+                if (prerequisiteNode == null || !prerequisiteNode.Available)
                 {
-                    continue;
+                    availableCache = false;
+                    return availableCache;
                 }
-
-                availableCache = false;
-                return availableCache;
             }
         }
 
@@ -279,13 +278,12 @@ public class ResearchNode : Node
                     continue;
                 }
 
-                if (researchPrerequisite.ResearchNode().Available)
+                var prerequisiteNode = researchPrerequisite.ResearchNode();
+                if (prerequisiteNode == null || !prerequisiteNode.Available)
                 {
-                    continue;
+                    availableCache = false;
+                    return availableCache;
                 }
-
-                availableCache = false;
-                return availableCache;
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid dereferencing null research nodes when evaluating prerequisite availability

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ecd11d11608328b05c2ce910a6d496