### PR TITLE
Fix crash when filtering out queued research projects

### DIFF
--- a/Source/ResearchTree/Queue.cs
+++ b/Source/ResearchTree/Queue.cs
@@ -251,6 +251,23 @@ public class Queue : WorldComponent
         return _instance._queue.Contains(node) && !node.Research.IsAnomalyResearch();
     }
 
+    public static IEnumerable<ResearchProjectDef> GetQueuedProjects()
+    {
+        var projects = new List<ResearchProjectDef>();
+
+        if (_instance != null)
+        {
+            projects.AddRange(_instance._queue.Select(n => n.Research));
+        }
+
+        if (_queueBackup != null && _queueBackup.Count > 0)
+        {
+            projects.AddRange(_queueBackup);
+        }
+
+        return projects.Distinct();
+    }
+
     public static void TryStartNext(ResearchProjectDef finished)
     {
         if (!IsQueued(finished.ResearchNode()))

--- a/Source/ResearchTree/Tree.cs
+++ b/Source/ResearchTree/Tree.cs
@@ -1554,6 +1554,16 @@ public static class Tree
                     }
                 }
 
+                foreach (var queuedProject in Queue.GetQueuedProjects())
+                {
+                    if (!validDefs.Contains(queuedProject))
+                    {
+                        continue;
+                    }
+
+                    includedDefs.Add(queuedProject);
+                }
+
                 if (includedDefs.Count > 0)
                 {
                     var queue = new Queue<ResearchProjectDef>(includedDefs);


### PR DESCRIPTION
## Summary
- expose the queued research projects so the tree rebuild can keep them
- force tab filtering to include queued research and their prerequisites

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ee1dc462e48328b8c21c81d1edb774