### PR TITLE
Support rebuilding when skip-completed filter is toggled

### DIFF
--- a/Languages/ChineseSimplified/Keyed/KeyedTranslations.xml
+++ b/Languages/ChineseSimplified/Keyed/KeyedTranslations.xml
@@ -80,6 +80,8 @@
   <Fluffy.ResearchTree.selectInvert>反选</Fluffy.ResearchTree.selectInvert>
   <Fluffy.ResearchTree.cancel>取消</Fluffy.ResearchTree.cancel>
   <Fluffy.ResearchTree.rebuild>重新生成</Fluffy.ResearchTree.rebuild>
+  <Fluffy.ResearchTree.SkipCompletedRegenerateTitle>需要重新生成</Fluffy.ResearchTree.SkipCompletedRegenerateTitle>
+  <Fluffy.ResearchTree.SkipCompletedRegeneratePrompt>已完成的研究在生成时被跳过。要再次显示这些项目需要重新生成研究树。是否现在重新生成？</Fluffy.ResearchTree.SkipCompletedRegeneratePrompt>
   <Fluffy.ResearchTree.refresh>已应用研究标签筛选并请求刷新研究树</Fluffy.ResearchTree.refresh>
   <!-- <Fluffy.ResearchTree.RClickForDetails>Right click for details</Fluffy.ResearchTree.RClickForDetails> -->
 </LanguageData>

--- a/Languages/ChineseTraditional/Keyed/KeyedTranslations.xml
+++ b/Languages/ChineseTraditional/Keyed/KeyedTranslations.xml
@@ -80,5 +80,7 @@
   <Fluffy.ResearchTree.selectInvert>反選</Fluffy.ResearchTree.selectInvert>
   <Fluffy.ResearchTree.cancel>取消</Fluffy.ResearchTree.cancel>
   <Fluffy.ResearchTree.rebuild>重新生成</Fluffy.ResearchTree.rebuild>
+  <Fluffy.ResearchTree.SkipCompletedRegenerateTitle>需要重新生成</Fluffy.ResearchTree.SkipCompletedRegenerateTitle>
+  <Fluffy.ResearchTree.SkipCompletedRegeneratePrompt>已完成的研究在生成時被略過。若要再次顯示這些項目必須重新生成研究樹，是否現在重新生成？</Fluffy.ResearchTree.SkipCompletedRegeneratePrompt>
   <Fluffy.ResearchTree.refresh>已套用研究標籤篩選並請求重新整理研究樹</Fluffy.ResearchTree.refresh>
 </LanguageData>

--- a/Languages/English/Keyed/KeyedTranslations.xml
+++ b/Languages/English/Keyed/KeyedTranslations.xml
@@ -80,5 +80,7 @@ Please use the load on first time opening if you experience this.</Fluffy.Resear
   <Fluffy.ResearchTree.selectInvert>Invert selection</Fluffy.ResearchTree.selectInvert>
   <Fluffy.ResearchTree.cancel>Cancel</Fluffy.ResearchTree.cancel>
   <Fluffy.ResearchTree.rebuild>Rebuild</Fluffy.ResearchTree.rebuild>
+  <Fluffy.ResearchTree.SkipCompletedRegenerateTitle>Rebuild required</Fluffy.ResearchTree.SkipCompletedRegenerateTitle>
+  <Fluffy.ResearchTree.SkipCompletedRegeneratePrompt>Completed research was skipped when the tree was rebuilt. Rebuilding the tree is required to show completed projects again. Rebuild now?</Fluffy.ResearchTree.SkipCompletedRegeneratePrompt>
   <Fluffy.ResearchTree.refresh>Applied research tag filter and requested research tree refresh.</Fluffy.ResearchTree.refresh>
 </LanguageData>

--- a/Source/ResearchTree/Extensions/ResearchProjectDef_Extensions.cs
+++ b/Source/ResearchTree/Extensions/ResearchProjectDef_Extensions.cs
@@ -178,6 +178,13 @@ public static class ResearchProjectDef_Extensions
         var researchNode = Tree.ResearchToNode(research) as ResearchNode;
         if (researchNode == null)
         {
+            var skipCompletedActive = Tree.CompletedResearchSkipped
+                                      || FluffyResearchTreeMod.instance?.Settings?.SkipCompleted == true;
+            if (skipCompletedActive && research.IsFinished)
+            {
+                return null;
+            }
+
             // It would be better to use warning instead of error. This is just a reminder.
             // eg: RimFridge_PowerFactorSetting def is hidden, but it is also finished.
             // So the patch of "ResearchManager.FinishProject" method will be executed to jump here.

--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -681,9 +681,39 @@ public class MainTabWindow_ResearchTree : MainTabWindow
 
         if (Widgets.ButtonInvisible(toggleRect, doMouseoverSound: true))
         {
-            FluffyResearchTreeMod.instance.Settings.SkipCompleted = !FluffyResearchTreeMod.instance.Settings.SkipCompleted;
-            Tree.ResetNodeAvailabilityCache();
-            Assets.RefreshResearch = true;
+            var settings = FluffyResearchTreeMod.instance.Settings;
+            void requestRebuild()
+            {
+                Tree.RequestRebuild(resetZoom: false, reopenResearchTab: false);
+                Assets.RefreshResearch = true;
+            }
+
+            if (!settings.SkipCompleted)
+            {
+                settings.SkipCompleted = true;
+                requestRebuild();
+            }
+            else
+            {
+                void disableAndRebuild()
+                {
+                    settings.SkipCompleted = false;
+                    requestRebuild();
+                }
+
+                if (Tree.CompletedResearchSkipped)
+                {
+                    Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation(
+                        "Fluffy.ResearchTree.SkipCompletedRegeneratePrompt".Translate(),
+                        disableAndRebuild,
+                        destructive: false,
+                        "Fluffy.ResearchTree.SkipCompletedRegenerateTitle".Translate()));
+                }
+                else
+                {
+                    disableAndRebuild();
+                }
+            }
         }
     }
 

--- a/Source/ResearchTree/Tree.cs
+++ b/Source/ResearchTree/Tree.cs
@@ -37,6 +37,10 @@ public static class Tree
 
     public static bool FirstLoadDone;
 
+    private static bool _completedResearchSkipped;
+
+    public static bool CompletedResearchSkipped => _completedResearchSkipped;
+
     private static readonly Dictionary<ResearchProjectDef, Node> ResearchToNodesCache = [];
 
     private static bool _loggedInitialDraw;
@@ -654,6 +658,8 @@ public static class Tree
         Queue.Notify_TreeWillReset();
 
         NoTabsSelected = false;
+
+        _completedResearchSkipped = false;
 
         Size = IntVec2.Zero;
         _nodes = null;
@@ -1604,6 +1610,17 @@ public static class Tree
                 NoTabsSelected = false;
             }
         }
+
+        var skipCompleted = SkipCompletedSetting;
+        var skippedCompletedProjects = false;
+        if (skipCompleted)
+        {
+            var filtered = researchList.Where(def => !def.IsFinished).ToList();
+            skippedCompletedProjects = filtered.Count != researchList.Count;
+            researchList = filtered;
+        }
+
+        _completedResearchSkipped = skipCompleted && skippedCompletedProjects;
 
         // Create nodes in parallel.
         _nodes = [];


### PR DESCRIPTION
## Summary
- skip generating finished research projects whenever the tree is rebuilt with the skip-completed option
- gate turning the skip-completed filter off behind a confirmation that triggers a tree rebuild when accepted
- avoid false missing-node warnings and add localized strings for the confirmation dialog

## Testing
- Not run (dotnet command is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ee2214255c8328bee82b31c1168bd6