### PR TITLE
Handle null prerequisite nodes in ResearchNode

### DIFF
--- a/Source/ResearchTree/ResearchNode.cs
+++ b/Source/ResearchTree/ResearchNode.cs
@@ -275,13 +275,18 @@ public class ResearchNode : Node
                     continue;
                 }
 
-                if (researchPrerequisite.ResearchNode().Available)
+                var prerequisiteNode = researchPrerequisite.ResearchNode();
+
+                if (prerequisiteNode == null || !prerequisiteNode.Available)
+                {
+                    availableCache = false;
+                    return availableCache;
+                }
+
+                if (prerequisiteNode.Available)
                 {
                     continue;
                 }
-
-                availableCache = false;
-                return availableCache;
             }
         }
 
@@ -294,13 +299,18 @@ public class ResearchNode : Node
                     continue;
                 }
 
-                if (researchPrerequisite.ResearchNode().Available)
+                var prerequisiteNode = researchPrerequisite.ResearchNode();
+
+                if (prerequisiteNode == null || !prerequisiteNode.Available)
+                {
+                    availableCache = false;
+                    return availableCache;
+                }
+
+                if (prerequisiteNode.Available)
                 {
                     continue;
                 }
-
-                availableCache = false;
-                return availableCache;
             }
         }
 
@@ -654,6 +664,7 @@ public class ResearchNode : Node
             (Research.prerequisites?.Where(rpd => !rpd.IsFinished) ?? [])
             .Concat(Research.hiddenPrerequisites?.Where(rpd => !rpd.IsFinished) ?? [])
             .Select(rpd => rpd.ResearchNode())
+            .Where(node => node != null)
             .ToList();
 
         var list = new List<ResearchNode>(enumerable);


### PR DESCRIPTION
## Summary
- Guard against missing prerequisite nodes while evaluating research availability
- Skip null prerequisite nodes when collecting required research recursively

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929b485fd208328b576cd1eebb8190a)