### PR TITLE
Handle null queue when drawing vanilla research labels

### DIFF
--- a/Source/ResearchTree/Queue.cs
+++ b/Source/ResearchTree/Queue.cs
@@ -248,7 +248,7 @@ public class Queue : WorldComponent
 
     public static bool IsQueued(ResearchNode node)
     {
-        return _instance._queue.Contains(node) && !node.Research.IsAnomalyResearch();
+        return _instance != null && _instance._queue.Contains(node) && !node.Research.IsAnomalyResearch();
     }
 
     public static IEnumerable<ResearchProjectDef> GetQueuedProjects()
@@ -376,6 +376,11 @@ public class Queue : WorldComponent
 
     public static void DrawLabelForVanillaWindow(Rect rect, ResearchProjectDef projectToStart)
     {
+        if (_instance == null)
+        {
+            return;
+        }
+
         if (projectToStart.IsAnomalyResearch())
         {
             return;


### PR DESCRIPTION
## Summary
- prevent DrawLabelForVanillaWindow from running before the queue component is initialized
- guard queue lookup to avoid null reference exceptions when the vanilla research tab renders

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ee69792c483289899cd290094177f)