### PR TITLE
Handle null research nodes when refreshing queue

### DIFF
--- a/Source/ResearchTree/Queue.cs
+++ b/Source/ResearchTree/Queue.cs
@@ -109,7 +109,7 @@ public class Queue : WorldComponent
 
     private static void enqueue(ResearchNode node, bool add)
     {
-        if (node.Research.IsAnomalyResearch())
+        if (node?.Research == null || node.Research.IsAnomalyResearch())
         {
             return;
         }
@@ -128,7 +128,7 @@ public class Queue : WorldComponent
 
     private static void reEnqueue(ResearchNode node)
     {
-        if (node.Research.IsAnomalyResearch())
+        if (node?.Research == null || node.Research.IsAnomalyResearch())
         {
             return;
         }


### PR DESCRIPTION
## Summary
- guard queue enqueue operations against null research nodes
- prevent errors when clearing selections leaves no visible research node to enqueue

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69593c8d94448328bc955dc76dc9451f)