### PR TITLE
Force research caches to refresh fully when reopening

### DIFF
--- a/Source/ResearchTree/ResearchNode.cs
+++ b/Source/ResearchTree/ResearchNode.cs
@@ -78,6 +78,12 @@ public class ResearchNode : Node
         currentCacheOrder = Assets.TotalAmountOfResearch;
     }
 
+    public static void ClearStaticCaches()
+    {
+        _buildingPresentCache.Clear();
+        _missingFacilitiesCache.Clear();
+    }
+
     public static implicit operator ResearchNode(ResearchProjectDef def)
     {
         return def.ResearchNode();
@@ -97,7 +103,7 @@ public class ResearchNode : Node
             return value;
         }
 
-        if (currentCacheOrder < Assets.TotalAmountOfResearch && hasCache)
+        if (!Assets.RefreshResearch && currentCacheOrder < Assets.TotalAmountOfResearch && hasCache)
         {
             currentCacheOrder++;
             return value;
@@ -224,7 +230,7 @@ public class ResearchNode : Node
             return availableCache;
         }
 
-        if (currentCacheOrder < Assets.TotalAmountOfResearch)
+        if (!Assets.RefreshResearch && currentCacheOrder < Assets.TotalAmountOfResearch)
         {
             currentCacheOrder++;
             return availableCache;
@@ -374,7 +380,7 @@ public class ResearchNode : Node
             return value;
         }
 
-        if (currentCacheOrder < Assets.TotalAmountOfResearch && hasCache)
+        if (!Assets.RefreshResearch && currentCacheOrder < Assets.TotalAmountOfResearch && hasCache)
         {
             currentCacheOrder++;
             return value;
@@ -434,6 +440,15 @@ public class ResearchNode : Node
         hasRefreshedBuildings = false;
         hasRefreshedFacilities = false;
         currentCacheOrder = cacheOrder;
+    }
+
+    public void ForceRefreshCaches()
+    {
+        ClearInstanceCaches();
+
+        availableCache = getCacheValue();
+        _ = missingFacilities(Research);
+        _ = buildingPresent(Research);
     }
 
     public override void Draw(Rect visibleRect, bool forceDetailedMode = false)

--- a/Source/ResearchTree/Tree.cs
+++ b/Source/ResearchTree/Tree.cs
@@ -1683,12 +1683,11 @@ public static class Tree
 
     public static void ResetNodeAvailabilityCache()
     {
-        foreach (var node in Nodes)
+        ResearchNode.ClearStaticCaches();
+
+        foreach (var node in Nodes.OfType<ResearchNode>())
         {
-            if (node is ResearchNode researchNode)
-            {
-                researchNode.ClearInstanceCaches();
-            }
+            node.ForceRefreshCaches();
         }
     }
 


### PR DESCRIPTION
## Summary
- add helpers to clear shared research caches and force each node to recompute availability
- refresh all node caches when resetting availability to avoid stale states across reopenings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a17c397548328ab5dd89a1001ff3e)