### PR TITLE
Ensure captured drags are absorbed during research view panning

### DIFF
--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -549,7 +549,8 @@ public class MainTabWindow_ResearchTree : MainTabWindow
 
         // 先确认鼠标在窗口内（不是只看 ViewRect）
         bool inWindow = Mouse.IsOver(this.windowRect);
-        bool inView = inWindow && InteractionRect.Contains(e.mousePosition);
+        // 仅在可见树区域内才认为是可用于平移的点击，避免将滚动条和外围按钮也当成平移起点
+        bool inView = inWindow && ViewRect_Inner.Contains(e.mousePosition);
 
         if (e.type == EventType.MouseDown && inWindow)
         {

--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -400,10 +400,10 @@ public class MainTabWindow_ResearchTree : MainTabWindow
             return;
         }
 
-        var pointerOverWindow = Mouse.IsOver(ViewRect);
+        var pointerOverViewport = Mouse.IsOver(ViewRect_Inner);
         var capturing = _capturedMouseButtons.Count > 0;
         var consumingDragFromWindow = capturing && (e.type == EventType.MouseDrag || e.type == EventType.MouseUp);
-        var absorbing = pointerOverWindow || _panning || consumingDragFromWindow;
+        var absorbing = pointerOverViewport || _panning || consumingDragFromWindow;
 
         if (!absorbing)
         {
@@ -415,7 +415,7 @@ public class MainTabWindow_ResearchTree : MainTabWindow
             case EventType.MouseDown:
             case EventType.ScrollWheel:
             case EventType.ContextClick:
-                if (!pointerOverWindow)
+                if (!pointerOverViewport)
                 {
                     return;
                 }
@@ -554,7 +554,10 @@ public class MainTabWindow_ResearchTree : MainTabWindow
 
         if (e.type == EventType.MouseDown && inWindow)
         {
-            _capturedMouseButtons.Add(e.button);
+            if (inView)
+            {
+                _capturedMouseButtons.Add(e.button);
+            }
 
             _dragging = inView && e.button == 0; // 只有左键才触发平移
             _panning = false;

--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -400,7 +400,7 @@ public class MainTabWindow_ResearchTree : MainTabWindow
             return;
         }
 
-        var pointerOverWindow = Mouse.IsOver(windowRect);
+        var pointerOverWindow = Mouse.IsOver(ViewRect);
         var capturing = _capturedMouseButtons.Count > 0;
         var consumingDragFromWindow = capturing && (e.type == EventType.MouseDrag || e.type == EventType.MouseUp);
         var absorbing = pointerOverWindow || _panning || consumingDragFromWindow;
@@ -547,8 +547,8 @@ public class MainTabWindow_ResearchTree : MainTabWindow
 
         var e = Event.current;
 
-        // 先确认鼠标在窗口内（不是只看 ViewRect）
-        bool inWindow = Mouse.IsOver(this.windowRect);
+        // 只在可交互的树视窗内才记录点击，避免捕获到窗口外围的游戏 UI
+        bool inWindow = Mouse.IsOver(ViewRect);
         // 仅在可见树区域内才认为是可用于平移的点击，避免将滚动条和外围按钮也当成平移起点
         bool inView = inWindow && ViewRect_Inner.Contains(e.mousePosition);
 

--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -402,8 +402,10 @@ public class MainTabWindow_ResearchTree : MainTabWindow
 
         var pointerOverWindow = Mouse.IsOver(windowRect);
         var capturing = _capturedMouseButtons.Count > 0;
+        var consumingDragFromWindow = capturing && (e.type == EventType.MouseDrag || e.type == EventType.MouseUp);
+        var absorbing = pointerOverWindow || _panning || consumingDragFromWindow;
 
-        if (!pointerOverWindow && !capturing)
+        if (!absorbing)
         {
             return;
         }
@@ -413,10 +415,15 @@ public class MainTabWindow_ResearchTree : MainTabWindow
             case EventType.MouseDown:
             case EventType.ScrollWheel:
             case EventType.ContextClick:
+                if (!pointerOverWindow)
+                {
+                    return;
+                }
+
                 e.Use();
                 break;
             case EventType.MouseDrag:
-                if (!capturing || !_capturedMouseButtons.Contains(e.button))
+                if (!_panning || !capturing || !_capturedMouseButtons.Contains(e.button))
                 {
                     return;
                 }
@@ -424,6 +431,12 @@ public class MainTabWindow_ResearchTree : MainTabWindow
                 e.Use();
                 break;
             case EventType.MouseUp:
+                if (!_panning || !_capturedMouseButtons.Contains(e.button))
+                {
+                    _capturedMouseButtons.Remove(e.button);
+                    return;
+                }
+
                 _capturedMouseButtons.Remove(e.button);
                 e.Use();
                 break;

--- a/Source/ResearchTree/MainTabWindow_ResearchTree.cs
+++ b/Source/ResearchTree/MainTabWindow_ResearchTree.cs
@@ -552,8 +552,17 @@ public class MainTabWindow_ResearchTree : MainTabWindow
         // 仅在可见树区域内才认为是可用于平移的点击，避免将滚动条和外围按钮也当成平移起点
         bool inView = inWindow && ViewRect_Inner.Contains(e.mousePosition);
 
-        if (e.type == EventType.MouseDown && inWindow)
+        if (e.type == EventType.MouseDown)
         {
+            if (!inWindow)
+            {
+                // 点击了窗口外的 UI，确保不会继续保留任何平移/捕获状态
+                _capturedMouseButtons.Clear();
+                _dragging = _panning = false;
+                _dragStart = _mousePosition = Vector2.zero;
+                return;
+            }
+
             if (inView)
             {
                 _capturedMouseButtons.Add(e.button);


### PR DESCRIPTION
## Summary
- absorb drag and mouse-up events that started inside the research window even if the pointer leaves while dragging
- prevent map clicks during panning without blocking scrollbar or toggle interactions

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab27f9ee48328b78b446808f33a49)