### PR TITLE
Allow queueing unavailable research when only prerequisites are missing

### DIFF
--- a/Source/ResearchTree/ResearchNode.cs
+++ b/Source/ResearchTree/ResearchNode.cs
@@ -238,11 +238,16 @@ public class ResearchNode : Node
 
         hasRefreshedAvailability = true;
 
-        if (missingFacilities(Research).Any() || Assets.SemiRandomResearchLoaded && Assets.SemiResearchEnabled ||
-            Assets.UsingRimedieval && !Assets.RimedievalAllowedResearchDefs.Contains(Research) ||
-            !Research.TechprintRequirementMet || !Research.InspectionRequirementsMet ||
-            Research.requiredResearchBuilding != null && !Research.PlayerHasAnyAppropriateResearchBench ||
-            !Research.PlayerMechanitorRequirementMet || !Research.AnalyzedThingsRequirementsMet)
+        var canStart = DebugSettings.godMode || Research.CanStartNow;
+
+        if (!canStart && Research.PrerequisitesCompleted)
+        {
+            availableCache = false;
+            return availableCache;
+        }
+
+        if (Assets.SemiRandomResearchLoaded && Assets.SemiResearchEnabled ||
+            Assets.UsingRimedieval && !Assets.RimedievalAllowedResearchDefs.Contains(Research))
         {
             availableCache = false;
             return availableCache;


### PR DESCRIPTION
## Summary
- allow research nodes to stay available for queueing when CanStartNow fails only because prerequisites are incomplete

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c75158a788328a2fa0f3ffa55dcdd)