### PR TITLE
Align research availability with facility and techprint requirements

### DIFF
--- a/Source/ResearchTree/ResearchNode.cs
+++ b/Source/ResearchTree/ResearchNode.cs
@@ -253,6 +253,12 @@ public class ResearchNode : Node
             return availableCache;
         }
 
+        if (!Research.TechprintRequirementMet || MissingFacilities()?.Any() == true)
+        {
+            availableCache = false;
+            return availableCache;
+        }
+
         object[] parameters = [Research, null];
         if (Assets.UsingVanillaVehiclesExpanded)
         {


### PR DESCRIPTION
### Motivation
- Ensure a research node is considered unavailable whenever required techprints or research facilities are missing so UI visuals match tooltip messaging.
- Prevent situations where a node appears "available" in the tree but its tooltip reports missing requirements.
- Keep the `Available` caching logic authoritative for `DrawAt`/`Color`/`EdgeColor` decisions that already depend on `Available`.

### Description
- Update `getCacheValue()` in `Source/ResearchTree/ResearchNode.cs` to set `availableCache = false` when `!Research.TechprintRequirementMet` or `MissingFacilities()?.Any() == true`.
- This makes the availability cache explicitly reflect missing techprints or facilities before further availability checks run.
- The change aligns tooltip output produced by `buildTips()` with the node's `Available` state used by rendering and interaction code.

### Testing
- No automated tests were run for this change.
- The change was limited to `Source/ResearchTree/ResearchNode.cs` and modifies the `getCacheValue()` availability logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696004d9fb488328b1e6d5c5e328e2d8)