### PR TITLE
Fix cache sync from undoing compressed rows

### DIFF
--- a/Source/ResearchTree/Tree.cs
+++ b/Source/ResearchTree/Tree.cs
@@ -910,7 +910,6 @@ public static class Tree
                 var bucket = _layerBuckets[x];
                 if (bucket == null || bucket.Count == 0) continue;
                 bucket.Sort((a, b) => a.Y.CompareTo(b.Y));
-                for (int i = 0; i < bucket.Count; i++) bucket[i].Y = i + 1;
             }
         }
         if (_layerSlots != null && _layerBuckets != null)


### PR DESCRIPTION
### Motivation

- The compression step removed dummy-only rows and remapped node `Y` coordinates to tighten the layout, but a subsequent cache rebuild re-normalized per-layer `Y` slots and restored the old spacing. 
- Re-normalizing in the cache sync loop caused `Size.z` and `Y` values to be reset and made dummy-only rows reappear, defeating compression. 
- The aim is to preserve the compressed `Y` mapping and the reduced vertical footprint after `removeEmptyRows` completes. 

### Description

- Stop re-normalizing per-layer `Y` positions during the cache synchronization phase in `removeEmptyRows` by removing the loop that assigned `bucket[i].Y = i + 1` after compression. 
- Keep the earlier `Size = new IntVec2(Size.x, Math.Max(0, maxY - removed))` update so the stored height reflects the compressed layout. 
- Still rebuild `_layerSlots` from `_layerBuckets` but without touching node `Y` values, preserving the compression mapping. 
- Change is limited to `Source/ResearchTree/Tree.cs` in the `removeEmptyRows` cache sync section. 

### Testing

- No automated tests were run as part of this change (not available). 
- Static inspection and repository scans were used to verify the modified code paths reference `_layerBuckets` and `_layerSlots` consistently. 
- The change is minimal and constrained to cache synchronization logic, but integration/manual testing is recommended to confirm the visual layout is compressed as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b389d2a88328abc50909dad166fb)