### PR TITLE
Refine cache availability checks in getCacheValue

### DIFF
--- a/Source/ResearchTree/ResearchNode.cs
+++ b/Source/ResearchTree/ResearchNode.cs
@@ -240,12 +240,6 @@ public class ResearchNode : Node
 
         var canStart = DebugSettings.godMode || Research.CanStartNow;
 
-        if (!canStart && Research.PrerequisitesCompleted)
-        {
-            availableCache = false;
-            return availableCache;
-        }
-
         if (Assets.SemiRandomResearchLoaded && Assets.SemiResearchEnabled ||
             Assets.UsingRimedieval && !Assets.RimedievalAllowedResearchDefs.Contains(Research))
         {
@@ -277,6 +271,12 @@ public class ResearchNode : Node
             return availableCache;
         }
 
+        if (canStart)
+        {
+            availableCache = true;
+            return availableCache;
+        }
+
         if (Research.prerequisites?.Any() != true && Research.hiddenPrerequisites?.Any() != true)
         {
             availableCache = true;
@@ -299,11 +299,6 @@ public class ResearchNode : Node
                     availableCache = false;
                     return availableCache;
                 }
-
-                if (prerequisiteNode.Available)
-                {
-                    continue;
-                }
             }
         }
 
@@ -322,11 +317,6 @@ public class ResearchNode : Node
                 {
                     availableCache = false;
                     return availableCache;
-                }
-
-                if (prerequisiteNode.Available)
-                {
-                    continue;
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Ensure `getCacheValue` treats a research as available when `canStart` is true after external gating (mods, facilities, techprint, world/level/overhaul blocks) so availability logic is consistent.
- Remove contradictory and redundant prerequisite-availability branches that duplicated work already covered by `canStart` to simplify and reduce potential bugs.

### Description
- Move reliance on `canStart` to after mod/facility/techprint and `Assets` gating checks and add an early-return that sets `availableCache = true` when `canStart` is true.  
- Keep gating checks that disable availability (`Assets.SemiRandomResearchLoaded`, Rimedieval, techprint/facilities, `Assets.IsDisabledMethod`, and world/grim/medieval blocks) before the `canStart` acceptance.  
- Remove redundant checks and `continue` branches inside the `Research.prerequisites` and `Research.hiddenPrerequisites` loops so prerequisites are only tested once for null/availability and failure returns false immediately.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69674db0f8508328a97d36c711ff9bf9)