### PR TITLE
Add mod option to toggle research connection lines

### DIFF
--- a/Languages/ChineseSimplified/Keyed/KeyedTranslations.xml
+++ b/Languages/ChineseSimplified/Keyed/KeyedTranslations.xml
@@ -40,6 +40,7 @@
   <Fluffy.ResearchTree.PreparingTree.LayoutNew>最终确定研究树布局</Fluffy.ResearchTree.PreparingTree.LayoutNew>
   <Fluffy.ResearchTree.VanillaGraphics>使用旧的图形方法（如果闪烁）</Fluffy.ResearchTree.VanillaGraphics>
   <Fluffy.ResearchTree.ShowCompletion>研究完成后弹出完成对话框</Fluffy.ResearchTree.ShowCompletion>
+  <Fluffy.ResearchTree.ShowResearchLines>显示研究连接线</Fluffy.ResearchTree.ShowResearchLines>
   <Fluffy.ResearchTree.StillLoading>研究树首次加载，可能需要一段时间</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>研究树未生成结束，请稍候……</Fluffy.ResearchTree.GenerationInProgress>
   <Fluffy.ResearchTree.NoTabsSelected>当前未选择任何研究项目</Fluffy.ResearchTree.NoTabsSelected>

--- a/Languages/ChineseTraditional/Keyed/KeyedTranslations.xml
+++ b/Languages/ChineseTraditional/Keyed/KeyedTranslations.xml
@@ -40,6 +40,7 @@
   <Fluffy.ResearchTree.PreparingTree.LayoutNew>最終確定研究樹佈局</Fluffy.ResearchTree.PreparingTree.LayoutNew>
   <Fluffy.ResearchTree.VanillaGraphics>使用舊的圖形方法（如果閃爍）</Fluffy.ResearchTree.VanillaGraphics>
   <Fluffy.ResearchTree.ShowCompletion>研究完成後彈出完成對話框</Fluffy.ResearchTree.ShowCompletion>
+  <Fluffy.ResearchTree.ShowResearchLines>顯示研究連線</Fluffy.ResearchTree.ShowResearchLines>
   <Fluffy.ResearchTree.StillLoading>研究樹首次載入，可能需要一段時間</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>研究樹尚未生成完成，請稍候……</Fluffy.ResearchTree.GenerationInProgress>
   <Fluffy.ResearchTree.NoTabsSelected>目前未選擇任何研究項目</Fluffy.ResearchTree.NoTabsSelected>

--- a/Languages/English/Keyed/KeyedTranslations.xml
+++ b/Languages/English/Keyed/KeyedTranslations.xml
@@ -39,6 +39,7 @@
   <Fluffy.ResearchTree.ResetLabel>Reset all settings</Fluffy.ResearchTree.ResetLabel>
   <Fluffy.ResearchTree.BackgroundColor>Background color</Fluffy.ResearchTree.BackgroundColor>
   <Fluffy.ResearchTree.ShowCompletion>Show completion message for finished research</Fluffy.ResearchTree.ShowCompletion>
+  <Fluffy.ResearchTree.ShowResearchLines>Show research connection lines</Fluffy.ResearchTree.ShowResearchLines>
   <Fluffy.ResearchTree.StillLoading>Tree is loading for the first time, this can take a while</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>Research tree generation is still in progress, please wait…</Fluffy.ResearchTree.GenerationInProgress>
   <Fluffy.ResearchTree.NoTabsSelected>No research projects are available because no research tags are selected.</Fluffy.ResearchTree.NoTabsSelected>

--- a/Languages/French/Keyed/KeyedTranslations.xml
+++ b/Languages/French/Keyed/KeyedTranslations.xml
@@ -40,6 +40,7 @@
   <Fluffy.ResearchTree.PreparingTree.LayoutNew>Finalisation de la présentation de l'arbre de recherche</Fluffy.ResearchTree.PreparingTree.LayoutNew>
   <Fluffy.ResearchTree.VanillaGraphics>Utiliser les anciennes méthodes graphiques (en cas de scintillement)</Fluffy.ResearchTree.VanillaGraphics>
   <Fluffy.ResearchTree.ShowCompletion>Afficher un message d'achèvement pour les recherches terminées</Fluffy.ResearchTree.ShowCompletion>
+  <Fluffy.ResearchTree.ShowResearchLines>Afficher les lignes de connexion des recherches</Fluffy.ResearchTree.ShowResearchLines>
   <Fluffy.ResearchTree.StillLoading>L'arbre se charge pour la première fois, ce qui peut prendre un certain temps.</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>La génération de l'arbre de recherche est toujours en cours, veuillez patienter…</Fluffy.ResearchTree.GenerationInProgress>
   <Fluffy.ResearchTree.UIScaleWarning>Lorsque l'échelle de l'interface utilisateur est supérieure à 1x, il se peut que les étiquettes de recherche soient coupées si vous utilisez l'option de chargement en arrière-plan.

--- a/Languages/German/Keyed/KeyedTranslations.xml
+++ b/Languages/German/Keyed/KeyedTranslations.xml
@@ -41,6 +41,7 @@
   <Fluffy.ResearchTree.PreparingTree.LayoutNew>Fertigstellung des Layouts des Forschungsbaums</Fluffy.ResearchTree.PreparingTree.LayoutNew>
   <Fluffy.ResearchTree.VanillaGraphics>Verwenden Sie die alten grafischen Methoden (bei Flackern)</Fluffy.ResearchTree.VanillaGraphics>
   <Fluffy.ResearchTree.ShowCompletion>Abschlussmeldung für beendete Recherchen anzeigen</Fluffy.ResearchTree.ShowCompletion>
+  <Fluffy.ResearchTree.ShowResearchLines>Verbindungslinien der Forschung anzeigen</Fluffy.ResearchTree.ShowResearchLines>
   <Fluffy.ResearchTree.StillLoading>Baum wird zum ersten Mal geladen, dies kann eine Weile dauern</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>Der Forschungsbaum wird noch erzeugt, bitte warten…</Fluffy.ResearchTree.GenerationInProgress>
   <Fluffy.ResearchTree.UIScaleWarning>Wenn Sie die UI-Skala größer als 1x verwenden, kann es vorkommen, dass die Forschungsbeschriftungen abgeschnitten werden, wenn Sie die Option zum Laden im Hintergrund verwenden.

--- a/Languages/Korean/Keyed/KeyedTranslations.xml
+++ b/Languages/Korean/Keyed/KeyedTranslations.xml
@@ -39,6 +39,7 @@
   <Fluffy.ResearchTree.PreparingTree.LayoutNew>연구 트리 배치 마무리</Fluffy.ResearchTree.PreparingTree.LayoutNew>
   <Fluffy.ResearchTree.VanillaGraphics>오래된 그래픽 방식을 사용 (깜빡임이 있을 때)</Fluffy.ResearchTree.VanillaGraphics>
   <Fluffy.ResearchTree.ShowCompletion>연구 완료 시 완료 메시지 표시</Fluffy.ResearchTree.ShowCompletion>
+  <Fluffy.ResearchTree.ShowResearchLines>연구 연결선 표시</Fluffy.ResearchTree.ShowResearchLines>
   <Fluffy.ResearchTree.StillLoading>연구 트리를 처음 불러오는 중입니다. 시간이 걸릴 수 있습니다.</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>연구 트리를 생성하는 중입니다. 잠시만 기다려 주세요…</Fluffy.ResearchTree.GenerationInProgress>
   <Fluffy.ResearchTree.UIScaleWarning>UI 배율이 1x보다 크면 백그라운드 로딩 옵션을 사용할 때 연구 레이블이 잘릴 수 있습니다.

--- a/Languages/Russian/Keyed/KeyedTranslations.xml
+++ b/Languages/Russian/Keyed/KeyedTranslations.xml
@@ -18,6 +18,7 @@
   <Fluffy.ResearchTree.LeadsTo>Ведет к</Fluffy.ResearchTree.LeadsTo>
   <Fluffy.ResearchTree.None>нет</Fluffy.ResearchTree.None>
   <Fluffy.ResearchTree.ShowCompletion>Показать сообщение о завершении исследования</Fluffy.ResearchTree.ShowCompletion>
+  <Fluffy.ResearchTree.ShowResearchLines>Показывать линии связей исследований</Fluffy.ResearchTree.ShowResearchLines>
   <Fluffy.ResearchTree.StillLoading>Древо исследований загружается в первый раз, это может занять некоторое время</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>Генерация древа исследований ещё не завершена, пожалуйста, подождите…</Fluffy.ResearchTree.GenerationInProgress>
   <Fluffy.ResearchTree.CurrentModVersion>Установленная версия мода: {0}</Fluffy.ResearchTree.CurrentModVersion>

--- a/Languages/Spanish/Keyed/KeyedTranslations.xml
+++ b/Languages/Spanish/Keyed/KeyedTranslations.xml
@@ -28,6 +28,7 @@
   <Fluffy.ResearchTree.SemiRandomResearchLoaded>El modo investigación semi-aleatoria no permite elegir la investigación libremente</Fluffy.ResearchTree.SemiRandomResearchLoaded>
   <Fluffy.ResearchTree.None>ninguno</Fluffy.ResearchTree.None>
   <Fluffy.ResearchTree.ShowCompletion>Mostrar mensaje de finalización para la investigación terminada</Fluffy.ResearchTree.ShowCompletion>
+  <Fluffy.ResearchTree.ShowResearchLines>Mostrar líneas de conexión de investigación</Fluffy.ResearchTree.ShowResearchLines>
   <Fluffy.ResearchTree.StillLoading>El árbol se está cargando por primera vez, esto puede tardar un poco</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>La generación del árbol de investigación aún no ha finalizado, espera un momento…</Fluffy.ResearchTree.GenerationInProgress>
   <Fluffy.ResearchTree.CurrentModVersion>Versión instalada del mod: {0}</Fluffy.ResearchTree.CurrentModVersion>

--- a/Languages/SpanishLatin/Keyed/KeyedTranslations.xml
+++ b/Languages/SpanishLatin/Keyed/KeyedTranslations.xml
@@ -29,6 +29,7 @@
   <Fluffy.ResearchTree.SemiRandomResearchLoaded>El modo investigación semi-aleatoria no permite elegir la investigación libremente</Fluffy.ResearchTree.SemiRandomResearchLoaded>
   <Fluffy.ResearchTree.None>ninguno</Fluffy.ResearchTree.None>
   <Fluffy.ResearchTree.ShowCompletion>Mostrar mensaje de finalización para la investigación terminada</Fluffy.ResearchTree.ShowCompletion>
+  <Fluffy.ResearchTree.ShowResearchLines>Mostrar líneas de conexión de investigación</Fluffy.ResearchTree.ShowResearchLines>
   <Fluffy.ResearchTree.StillLoading>El árbol se está cargando por primera vez, esto puede tardar un poco</Fluffy.ResearchTree.StillLoading>
   <Fluffy.ResearchTree.GenerationInProgress>La generación del árbol de investigación aún no ha finalizado, espera un momento…</Fluffy.ResearchTree.GenerationInProgress>
   <Fluffy.ResearchTree.CurrentModVersion>Versión instalada del mod: {0}</Fluffy.ResearchTree.CurrentModVersion>

--- a/Source/ResearchTree/FluffyResearchTreeMod.cs
+++ b/Source/ResearchTree/FluffyResearchTreeMod.cs
@@ -103,6 +103,7 @@ internal class FluffyResearchTreeMod : Mod
         listing_Standard.CheckboxLabeled("Fluffy.ResearchTree.ReverseShift".Translate(), ref Settings.ReverseShift, "Fluffy.ResearchTree.ReverseShiftTT".Translate());
         listing_Standard.CheckboxLabeled("Fluffy.ResearchTree.PauseOnOpen".Translate(), ref Settings.PauseOnOpen);
         listing_Standard.CheckboxLabeled("Fluffy.ResearchTree.ShowCompletion".Translate(), ref Settings.ShowCompletion);
+        listing_Standard.CheckboxLabeled("Fluffy.ResearchTree.ShowResearchLines".Translate(), ref Settings.ShowResearchLines);
         if (ModsConfig.IdeologyActive)
         {
             listing_Standard.CheckboxLabeled("Fluffy.ResearchTree.NoIdeologyPopup".Translate(),

--- a/Source/ResearchTree/FluffyResearchTreeSettings.cs
+++ b/Source/ResearchTree/FluffyResearchTreeSettings.cs
@@ -21,6 +21,7 @@ internal class FluffyResearchTreeSettings : ModSettings
     public bool NoIdeologyPopup;
     public bool OverrideResearch = true;
     public bool PauseOnOpen = true;
+    public bool ShowResearchLines = true;
 
     public bool ShowCompletion;
     public bool ReverseShift;
@@ -59,6 +60,7 @@ internal class FluffyResearchTreeSettings : ModSettings
     {
         base.ExposeData();
         Scribe_Values.Look(ref PauseOnOpen, "PauseOnOpen", true);
+        Scribe_Values.Look(ref ShowResearchLines, "ShowResearchLines", true);
         Scribe_Values.Look(ref CtrlFunction, "CtrlFunction", true);
         Scribe_Values.Look(ref OverrideResearch, "OverrideResearch", true);
         Scribe_Values.Look(ref ShowCompletion, "ShowCompletion");
@@ -83,6 +85,7 @@ internal class FluffyResearchTreeSettings : ModSettings
     public void Reset()
     {
         PauseOnOpen = true;
+        ShowResearchLines = true;
         CtrlFunction = true;
         OverrideResearch = true;
         ShowCompletion = false;

--- a/Source/ResearchTree/Tree.cs
+++ b/Source/ResearchTree/Tree.cs
@@ -283,6 +283,15 @@ public static class Tree
                 return false;
             }
 
+            var settings = FluffyResearchTreeMod.instance?.Settings;
+            if (settings != null && !settings.ShowResearchLines)
+            {
+                if (!(Start.Highlighted || End.Highlighted))
+                {
+                    return false;
+                }
+            }
+
             if (!Start.IsVisible || !End.IsVisible)
             {
                 return false;


### PR DESCRIPTION
### Motivation

- Add a user-facing option to control whether research connection lines are drawn in the research tree, with the default being visible, and when hidden only show lines for highlighted/hovered nodes.

### Description

- Add a new persisted setting `ShowResearchLines` (default `true`) in `FluffyResearchTreeSettings` and initialize/reset it in `Reset` and `ExposeData`.
- Expose the toggle in the mod settings UI by adding a checkbox in `FluffyResearchTreeMod.DoSettingsWindowContents` using the translation key `Fluffy.ResearchTree.ShowResearchLines`.
- Short-circuit edge drawing in `Tree.CollapsedEdge.ShouldDraw` to return `false` when `ShowResearchLines` is disabled unless either `Start.Highlighted` or `End.Highlighted` is true, preserving existing visibility/skip logic otherwise.
- Add localization entries for the new label `Fluffy.ResearchTree.ShowResearchLines` to the English and multiple translated `KeyedTranslations.xml` language files.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cfbc63ccc8328a6eb517e4e65605e)